### PR TITLE
Use `keyof typeof ` for enums

### DIFF
--- a/src/__tests__/__snapshots__/strictMode.test.ts.snap
+++ b/src/__tests__/__snapshots__/strictMode.test.ts.snap
@@ -35,7 +35,7 @@ export interface GQLUser {
    */
   username: string;
   email: string;
-  role: GQLUserRole;
+  role: keyof typeof GQLUserRole;
   
   /**
    * Url to the image

--- a/src/__tests__/__snapshots__/typeScriptGenerator.test.ts.snap
+++ b/src/__tests__/__snapshots__/typeScriptGenerator.test.ts.snap
@@ -35,7 +35,7 @@ export interface GQLUser {
    */
   username: string;
   email: string;
-  role: GQLUserRole;
+  role: keyof typeof GQLUserRole;
 
   /**
    * Url to the image

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,6 +156,9 @@ export const getTypeToTS = (field: any, prefix: string, nonNullable: boolean = f
   if (field.kind === 'LIST') {
     tsType = getTypeToTS(field.ofType, prefix, false);
     tsType = `Array<${tsType}>`;
+  } else if (field.kind === 'ENUM') {
+    tsType = gqlScalarToTS(field.name, prefix);
+    tsType = `keyof typeof ${tsType}`;
   } else {
     tsType = gqlScalarToTS(field.name, prefix);
   }


### PR DESCRIPTION
Enum types in TypeScript are not actually just the enum values. The types land up being restricted to `string` internally rather than the actual values. This makes the types a little stricter.