### PR TITLE
Allow async subscription resolver

### DIFF
--- a/src/__tests__/__snapshots__/option.resolver.test.ts.snap
+++ b/src/__tests__/__snapshots__/option.resolver.test.ts.snap
@@ -2354,12 +2354,12 @@ export interface RootSubscriptionToUserLoggedInArgs {
 }
 export interface RootSubscriptionToUserLoggedInResolver<TParent = any, TResult = any> {
   resolve?: (parent: TParent, args: RootSubscriptionToUserLoggedInArgs, context: any, info: GraphQLResolveInfo) => TResult | Promise<TResult>;
-  subscribe: (parent: TParent, args: RootSubscriptionToUserLoggedInArgs, context: any, info: GraphQLResolveInfo) => AsyncIterator<TResult>;
+  subscribe: (parent: TParent, args: RootSubscriptionToUserLoggedInArgs, context: any, info: GraphQLResolveInfo) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
 }
 
 export interface RootSubscriptionToSaleMadeResolver<TParent = any, TResult = any> {
   resolve?: (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo) => TResult | Promise<TResult>;
-  subscribe: (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo) => AsyncIterator<TResult>;
+  subscribe: (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
 }
 "
 `;

--- a/src/typescriptResolverGenerator.ts
+++ b/src/typescriptResolverGenerator.ts
@@ -162,7 +162,8 @@ export class TSResolverGenerator {
             const TParent = this.guessTParent(objectType.name);
             const TResult = this.guessTResult(field);
             const returnType = this.options.asyncResult ? 'TResult | Promise<TResult>' : 'TResult';
-            const subscriptionReturnType = 'AsyncIterator<TResult>';
+            const subscriptionReturnType = 
+                this.options.asyncResult ? 'AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>' : 'AsyncIterator<TResult>';
             const fieldResolverTypeDef = !isSubscription
                 ? [
                     `export interface ${fieldResolverName}<TParent = ${TParent}, TResult = ${TResult}> {`,


### PR DESCRIPTION
This allows subscription resolvers to be async, something that the previous variant did not allow
despite it being allowed in for example Apollo.