### PR TITLE
feat: support graphqls file extension for schema files

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ function klawSync(path: string, filterRegex: RegExp, fileNames: string[] = []) {
 }
 
 export const introspectSchemaViaLocalFile = async (path: string): Promise<IntrospectionQuery> => {
-    const files = klawSync(path, /\.(graphql|gql)$/);
+    const files = klawSync(path, /\.(graphql|gql|graphqls)$/);
     const allTypeDefs = files.map(filePath => fs.readFileSync(filePath, 'utf-8')).join('\n');
     return await introspectSchemaStr(allTypeDefs);
 };


### PR DESCRIPTION
It's also a common practice to name schema files *.graphqls. Simply support files with this extension.