### PR TITLE
Support graphql v16

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ This module aim to do the Server counterpart: from a Schema Definition, generate
 types to make it type-safed when developing GraphQL server (mainly resolvers)
 
 ## Compatibility
-| graphql-schema-typescript |  graphql  |
-|---------------------------|-----------|
-|1.5                        |  ^14.0.0  |
-|1.4                        | 0.11~0.13 |
+| graphql-schema-typescript |  graphql         |
+|---------------------------|------------------|
+|1.6                        | ^16.0.0          |
+|1.5                        | ^14.0.0, ^15.0.0 |
+|1.4                        | 0.11~0.13        |
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-schema-typescript",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Generate TypeScript from GraphQL's schema type definitions",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -20,6 +20,7 @@
   "author": "Jack Dang <jack.dang@itutorworld.com.au>",
   "license": "MIT",
   "devDependencies": {
+    "@graphql-tools/schema": "^8.3.1",
     "@playlyfe/gql": "2.6.2",
     "@types/fs-extra": "4.0.4",
     "@types/graphql": "0.11.5",
@@ -28,8 +29,7 @@
     "@types/yargs": "^15.0.0",
     "del-cli": "^2.0.0",
     "fs-extra": "4.0.2",
-    "graphql": "^15.5.0",
-    "graphql-tools": "2.7.2",
+    "graphql": "^16.0.0",
     "jest": "^26.0.0",
     "ts-jest": "^26.0.0",
     "tslint": "5.8.0",
@@ -40,7 +40,7 @@
     "yargs": "^16.0.0"
   },
   "peerDependencies": {
-    "graphql": "^14.0.0",
+    "graphql": "^16.0.0",
     "typescript": "*"
   },
   "jest": {
@@ -49,7 +49,7 @@
       "./src/setupTest.ts"
     ],
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".(ts|tsx)": "ts-jest"
     },
     "testRegex": "/__tests__/.*\\.test\\.ts$",
     "moduleFileExtensions": [

--- a/src/__tests__/testSchema/index.ts
+++ b/src/__tests__/testSchema/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { makeExecutableSchema } from 'graphql-tools';
-import { GraphQLSchema, introspectionQuery, graphql } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { GraphQLSchema, getIntrospectionQuery, graphql } from 'graphql';
 
 const gqlFiles = fs.readdirSync(__dirname).filter(f => f.endsWith('.gql') || f.endsWith('.graphql'));
 

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -17,7 +17,7 @@ export const executeCommand = (command: string, options?: childProcess.ExecOptio
             if (exitCode !== 0) {
                 reject(`Command: ${command} return non-0 exit code: ${exitCode}`);
             } else {
-                resolve();
+                resolve(undefined);
             }
         });
         process.on('error', err => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,13 +16,15 @@ const camelCase = require('camelcase');
  * Send introspection query to a graphql schema
  */
 export const introspectSchema = async (schema: GraphQLSchema): Promise<IntrospectionQuery> => {
-    const { data, errors } = await graphql(schema, getIntrospectionQuery());
+    const { data, errors } = await graphql({
+        schema: schema, source: getIntrospectionQuery()
+    });
 
     if (errors) {
         throw errors;
     }
 
-    return data as IntrospectionQuery;
+    return data as unknown as IntrospectionQuery;
 };
 
 async function introspectSchemaStr(schemaStr: string): Promise<IntrospectionQuery> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,6 +279,31 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@graphql-tools/merge@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.2.1.tgz#bf83aa06a0cfc6a839e52a58057a84498d0d51ff"
+  integrity sha512-Q240kcUszhXiAYudjuJgNuLgy9CryDP3wp83NOZQezfA6h3ByYKU7xI6DiKrdjyVaGpYN3ppUmdj0uf5GaXzMA==
+  dependencies:
+    "@graphql-tools/utils" "^8.5.1"
+    tslib "~2.3.0"
+
+"@graphql-tools/schema@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.3.1.tgz#1ee9da494d2da457643b3c93502b94c3c4b68c74"
+  integrity sha512-3R0AJFe715p4GwF067G5i0KCr/XIdvSfDLvTLEiTDQ8V/hwbOHEKHKWlEBHGRQwkG5lwFQlW1aOn7VnlPERnWQ==
+  dependencies:
+    "@graphql-tools/merge" "^8.2.1"
+    "@graphql-tools/utils" "^8.5.1"
+    tslib "~2.3.0"
+    value-or-promise "1.0.11"
+
+"@graphql-tools/utils@^8.5.1":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.5.3.tgz#404062e62cae9453501197039687749c4885356e"
+  integrity sha512-HDNGWFVa8QQkoQB0H1lftvaO1X5xUaUDk1zr1qDe0xN1NL0E/CrQdJ5UKLqOvH4hkqVUPxQsyOoAZFkaH6rLHg==
+  dependencies:
+    tslib "~2.3.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -638,13 +663,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@wry/equality@^0.1.2":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
-  integrity sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==
-  dependencies:
-    tslib "^1.9.3"
-
 abab@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -744,16 +762,6 @@ apollo-codegen@0.10.13:
     node-fetch "^1.5.3"
     source-map-support "^0.4.2"
     yargs "^7.0.1"
-
-apollo-utilities@^1.0.1:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.4.tgz#6129e438e8be201b6c55b0f13ce49d2c7175c9cf"
-  integrity sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==
-  dependencies:
-    "@wry/equality" "^0.1.2"
-    fast-json-stable-stringify "^2.0.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1459,11 +1467,6 @@ dentist@1.0.3:
   resolved "https://registry.yarnpkg.com/dentist/-/dentist-1.0.3.tgz#ef194a9753420a150c2423c7cb64cf9887d721b4"
   integrity sha1-7xlKl1NCChUMJCPHy2TPmIfXIbQ=
 
-deprecated-decorator@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
-  integrity sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=
-
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -1970,15 +1973,6 @@ graphql-language-service-utils@0.0.10:
     graphql "^0.9.6"
     graphql-language-service-types "0.0.16"
 
-graphql-tools@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-2.7.2.tgz#03104a155b15f8441b0e5a7113b12b9512341a9e"
-  integrity sha512-BhL37XtfH1XCDoMi/RR+ApOm/zVpGE0GFRdZhRaQn3wd6W9rBIVoAGa7/k/VimROy45UKDO4DIyhnbGAZW1lqg==
-  dependencies:
-    apollo-utilities "^1.0.1"
-    deprecated-decorator "^0.1.6"
-    uuid "^3.1.0"
-
 graphql@0.9.6, graphql@^0.9.5, graphql@^0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.9.6.tgz#514421e9d225c29dfc8fd305459abae58815ef2c"
@@ -1986,10 +1980,10 @@ graphql@0.9.6, graphql@^0.9.5, graphql@^0.9.6:
   dependencies:
     iterall "^1.0.0"
 
-graphql@^15.5.0:
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
-  integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
+graphql@^16.0.0:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.0.1.tgz#93a13cd4e0e38ca8d0832e79614c8578bfd34f10"
+  integrity sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -4476,13 +4470,6 @@ trim-newlines@^2.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
   integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
 
-ts-invariant@^0.4.0:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
-  integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
-  dependencies:
-    tslib "^1.9.3"
-
 ts-jest@^26.0.0:
   version "26.4.4"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
@@ -4500,10 +4487,15 @@ ts-jest@^26.0.0:
     semver "7.x"
     yargs-parser "20.x"
 
-tslib@^1.10.0, tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.3:
+tslib@^1.7.1, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@~2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslint@5.8.0:
   version "5.8.0"
@@ -4639,7 +4631,7 @@ user-home@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-uuid@^3.1.0, uuid@^3.3.2:
+uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -4665,6 +4657,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-or-promise@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.11.tgz#3e90299af31dd014fe843fe309cefa7c1d94b140"
+  integrity sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Add support for graphql 16.

Majority of changes taken from #61, so kudos to @tony!

Anyone, please take a look  at `src/utils.ts#L27`

Originally error looks like at :

```
Conversion of type 'ObjMap<unknown>' to type 'IntrospectionQuery' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
Property '__schema' is missing in type 'ObjMap<unknown>' but required in type 'IntrospectionQuery'.
```

There should be a better way how to handle type of data. 

I assume some sort of resolver is required  when executing graphql introspection query, so  type of data contains key `__schema`.